### PR TITLE
Fix HSRP version command

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ Note: NAT Table entries are kept for 24h after the last use by default.
 | (config-if)# standby [group-number] ip <ip>         | Join HSRP Group                                                  |
 | (config-if)# standby [group-number] priority <prio> | (optional) Set prio of this router.                              |
 | (config-if)# standby [group-number] preempt         | (optional) Preempt other routers when this router becomes active |
-| (config-if)# standby {1,2}                          | (optional) Set HSRP Version                                      |
+| (config-if)# standby version {1,2}                  | (optional) Set HSRP Version                                      |
 
 ### Troubleshooting HSRP
 


### PR DESCRIPTION
Router (config-if)# standby version 2 | Configures HSRP to use version 2. HSRP version 1 is the default.